### PR TITLE
Arbritary plane slicing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# 4 space indentation
+[*.py]
+indent_style = tab
+indent_size = 4
+max_line_length = 80

--- a/Model3D.py
+++ b/Model3D.py
@@ -451,7 +451,8 @@ class STLModel(Model3D):
 		'''Process the contents of a text file as a generator.'''
 		items = contents.split()
 		del contents
-		items = [s.strip() for s in items]
+		items = [s.strip().decode("utf-8")  for s in items]
+
 		try:
 			sn = items.index("solid")+1
 			en = items.index("facet")

--- a/Model3D.py
+++ b/Model3D.py
@@ -1,6 +1,7 @@
 from hashlib import md5
 from struct import unpack
 from math import fabs, sqrt
+from sympy import Plane, Point3D, Segment3D
 
 # This is the difference between points, below which we can consider them equal.
 DIFFERENCE_LIMIT = 1e-7
@@ -239,6 +240,30 @@ class Triangle(object):
 
 		return pair
 
+	def find_interpolated_points_at_plane(self, plane):
+		pair = []
+		v1 = Point3D(self.vertices[0].x, self.vertices[0].y, self.vertices[0].z)
+		v2 = Point3D(self.vertices[1].x, self.vertices[1].y, self.vertices[1].z)
+		v3 = Point3D(self.vertices[2].x, self.vertices[2].y, self.vertices[2].z)
+		l1 = Segment3D(v1, v2)
+		l2 = Segment3D(v1, v3)
+		l3 = Segment3D(v2, v3)
+
+		i1 = plane.intersection(l1)[0]
+		i2 = plane.intersection(l2)[0]
+		i3 = plane.intersection(l3)[0]
+
+		if l1.contains(i1):
+			pair.append(i1)
+		if l2.contains(i2):
+			pair.append(i2)
+		if l3.contains(i3):
+			pair.append(i3)
+		if(len(pair) > 0):
+			print(pair)
+			print(len(pair))
+		
+
 class Model3D(object):
 	'''Abstract Class to represent 3D objects. Cannot usually be used '''
 
@@ -399,6 +424,14 @@ class Model3D(object):
 				output.append((points[0], points[1]))
 
 		return output
+
+	def slice_at_plane(self, targetz, plane):
+		'''Function to slice the model at certain transforms of a plane.
+		Returns an array of tuples, describing the various lines between
+		points'''
+		min_dist = 1000000000
+		for triangle in self.triangles:
+			triangle.find_interpolated_points_at_plane(plane)
 
 class STLModel(Model3D):
 

--- a/pySlice.py
+++ b/pySlice.py
@@ -26,87 +26,44 @@ THE SOFTWARE.
 """
 from Model3D import STLModel, Vector3, Normal
 from svgwrite import Drawing, rgb
-from sympy import Plane, Point3D
+from sympy import Plane, Point3D, Line
 
 import sys
 
 #@profile
-def slice_file(f=None, resolution=0.1):
+def slice_file(image_position_patient_array,
+			   image_orientation_patient,
+			   output_path=None,
+			   input_path=None):
 	print("Status: Loading File.")
 
-	model = STLModel(f)
-	scale = 10
+	model = STLModel(input_path)
 	stats = model.stats()
 
-	sub_vertex = Vector3(stats['extents']['x']['lower'], stats['extents']['y']['lower'], stats['extents']['z']['lower'])
-	add_vertex = Vector3(0.5,0.5,0.5)
-
-	model.xmin = model.xmax = None
-	model.ymin = model.ymax = None
-	model.zmin = model.zmax = None
-
-	print("Status: Scaling Triangles.")
-
-	for triangle in model.triangles:
-		triangle.vertices[0] -= sub_vertex
-		triangle.vertices[1] -= sub_vertex
-		triangle.vertices[2] -= sub_vertex
-
-		# The lines above have no effect on the normal.
-
-		triangle.vertices[0] = (triangle.vertices[0] * scale) + add_vertex
-		triangle.vertices[1] = (triangle.vertices[1] * scale) + add_vertex
-		triangle.vertices[2] = (triangle.vertices[2] * scale) + add_vertex
-
-		# Recalculate the triangle normal
-
-		u = model.triangles[0].vertices[1] - model.triangles[0].vertices[0]
-		v = model.triangles[0].vertices[2] - model.triangles[0].vertices[0]
-
-		triangle.n = Normal((u.y * v.z)-(u.z*v.y), (u.z*v.x)-(u.x*v.z), (u.x*v.y)-(u.y*v.x))
-		model.update_extents(triangle)
+	print(stats)
 
 	print("Status: Calculating Slices")
 
-	interval = scale * resolution
-	stats = model.stats()
-	print(stats)
+	v1 = Point3D(image_orientation_patient[0][0],
+				 image_orientation_patient[0][1],
+				 image_orientation_patient[0][2])
+	v2 = Point3D(image_orientation_patient[1][0],
+				 image_orientation_patient[1][1],
+				 image_orientation_patient[1][2])
+	org = Point3D(0, 0, 0) 
+	
+	for i, slice_loc in enumerate(image_position_patient_array):
+		slice_loc = Point3D(slice_loc[0], slice_loc[1], slice_loc[2])
 
-	for targetz in range(0, int(stats['extents']['z']['upper']), int(interval)):
-		dwg = Drawing('outputs/svg/'+str(targetz)+'.svg', profile='tiny')
-
-		v1 = Point3D(0.589927, 0.778019, -0.216038)
-		v2 = Point3D(-0.340419, -0.002971, -0.940269)
-		org = Point3D(0, 0, 0)
-
-		slice_loc = Point3D(91.744177, -237.718833, 183.578566)
-		
+		dwg = Drawing(output_path + str(i) + '.svg', profile='tiny')
 		plane = Plane(v1 + slice_loc,
 					  v2 + slice_loc,
 					  org + slice_loc)
-		pairs = model.slice_at_plane(targetz, plane)
+		x_axis = Line(org + slice_loc, v1 + slice_loc)
+		y_axis = Line(org + slice_loc, v2 + slice_loc)
+		pairs = model.slice_at_plane(plane, x_axis, y_axis)
 		for pair in pairs:
 			dwg.add(dwg.line(pair[0], pair[1], stroke=rgb(0, 0, 0, "%")))
 		dwg.save()
 
 	print("Status: Finished Outputting Slices")
-
-
-if __name__ == '__main__':
-	# Run as a command line program.
-
-	import argparse
-	parser = argparse.ArgumentParser(
-						description='Takes a 3D Model, and slices it at regular intervals')
-	parser.add_argument('file',
-						metavar='FILE',
-						help='File to be sliced',
-						nargs='?',
-						default='models/yoda.stl',
-						type=argparse.FileType('rb'))
-	parser.add_argument('-r', '--resolution', type=float,
-						default=0.1,
-						help='The Z-Axis resolution of the printer, in mms')
-
-	args = parser.parse_args()
-	slice_file(args.file, args.resolution)

--- a/pySlice.py
+++ b/pySlice.py
@@ -26,6 +26,8 @@ THE SOFTWARE.
 """
 from Model3D import STLModel, Vector3, Normal
 from svgwrite import Drawing, rgb
+from sympy import Plane, Point3D
+
 import sys
 
 #@profile
@@ -72,7 +74,17 @@ def slice_file(f=None, resolution=0.1):
 
 	for targetz in range(0, int(stats['extents']['z']['upper']), int(interval)):
 		dwg = Drawing('outputs/svg/'+str(targetz)+'.svg', profile='tiny')
-		pairs = model.slice_at_z(targetz)
+
+		v1 = Point3D(0.589927, 0.778019, -0.216038)
+		v2 = Point3D(-0.340419, -0.002971, -0.940269)
+		org = Point3D(0, 0, 0)
+
+		slice_loc = Point3D(91.744177, -237.718833, 183.578566)
+		
+		plane = Plane(v1 + slice_loc,
+					  v2 + slice_loc,
+					  org + slice_loc)
+		pairs = model.slice_at_plane(targetz, plane)
 		for pair in pairs:
 			dwg.add(dwg.line(pair[0], pair[1], stroke=rgb(0, 0, 0, "%")))
 		dwg.save()


### PR DESCRIPTION
Adds the ability to slice on an arbitrary plane through the origin and then at parallel planes through a set of points...

This can be used to create 2d maps through a mesh from a given set of dicom images.

Removes some stuff from the basic script:
- Command line argument parsing
- The scaling code as it makes the plane computations more complicated
- The code normalizing the data to positive coordinates, again this complicated the place slicing calculations so it was easiest to skip it